### PR TITLE
Add alerts service for outbound notifications

### DIFF
--- a/alerts/Dockerfile
+++ b/alerts/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-alpine
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY src/ /app/
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8500"]

--- a/alerts/requirements.txt
+++ b/alerts/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+httpx
+pydantic[email]
+azure-identity
+azure-keyvault-secrets
+azure-core
+sqlalchemy
+psycopg2-binary

--- a/alerts/src/app.py
+++ b/alerts/src/app.py
@@ -1,0 +1,164 @@
+"""FastAPI application exposing the alert service."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, HTTPException, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, EmailStr, root_validator
+
+from .channels import ChannelStatus, send_email_alert, send_telegram_alert
+from .db import create_alert_log, init_db
+
+
+app = FastAPI(title="Alerts Service")
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    """Ensure database structures are created when the service starts."""
+
+    await asyncio.to_thread(init_db)
+
+
+class TelegramTarget(BaseModel):
+    """Target configuration for Telegram alerts."""
+
+    chat_id: str
+
+
+class EmailTarget(BaseModel):
+    """Target configuration for email alerts."""
+
+    recipients: List[EmailStr]
+    subject: Optional[str] = None
+    body: Optional[str] = None
+
+    @root_validator
+    def check_recipients(cls, values: dict) -> dict:
+        recipients = values.get("recipients") or []
+        if not recipients:
+            raise ValueError("At least one recipient is required for email alerts")
+        return values
+
+
+class AlertRequest(BaseModel):
+    """Incoming alert definition."""
+
+    message: str
+    telegram: Optional[TelegramTarget] = None
+    email: Optional[EmailTarget] = None
+
+    @root_validator
+    def check_channels(cls, values: dict) -> dict:
+        if not values.get("telegram") and not values.get("email"):
+            raise ValueError("At least one delivery channel must be provided")
+        return values
+
+
+async def _safe_execute(channel: str, target, coro) -> ChannelStatus:
+    try:
+        return await coro
+    except Exception as exc:
+        return {
+            "channel": channel,
+            "target": target,
+            "success": False,
+            "error": str(exc),
+            "detail": None,
+        }
+
+
+@app.get("/health")
+async def health() -> dict:
+    """Health-check endpoint."""
+
+    return {"status": "ok"}
+
+
+@app.post("/alerts")
+async def create_alert(request: AlertRequest) -> JSONResponse:
+    """Dispatch an alert to the requested channels."""
+
+    tasks = []
+    audit_entries: List[Dict[str, Any]] = []
+
+    if request.telegram is not None:
+        tasks.append(
+            _safe_execute(
+                "telegram",
+                request.telegram.chat_id,
+                send_telegram_alert(request.telegram.chat_id, request.message),
+            )
+        )
+        audit_entries.append(
+            {
+                "channel": "telegram",
+                "target": request.telegram.chat_id,
+                "message": request.message,
+                "subject": None,
+            }
+        )
+
+    if request.email is not None:
+        email_target = request.email
+        subject = email_target.subject or "Alert Notification"
+        body = email_target.body or request.message
+        recipients = [str(r) for r in email_target.recipients]
+        tasks.append(
+            _safe_execute(
+                "email",
+                recipients,
+                send_email_alert(recipients, subject, body),
+            )
+        )
+        audit_entries.append(
+            {
+                "channel": "email",
+                "target": recipients,
+                "message": body,
+                "subject": subject,
+            }
+        )
+
+    if not tasks:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No delivery channels requested")
+
+    results: List[ChannelStatus] = await asyncio.gather(*tasks)
+    log_tasks = [
+        asyncio.to_thread(
+            create_alert_log,
+            channel=entry["channel"],
+            target=entry["target"],
+            message=entry["message"],
+            subject=entry["subject"],
+            success=result.get("success", False),
+            error=result.get("error"),
+            detail=result.get("detail"),
+        )
+        for entry, result in zip(audit_entries, results)
+    ]
+
+    if log_tasks:
+        log_results = await asyncio.gather(*log_tasks, return_exceptions=True)
+        for idx, log_result in enumerate(log_results):
+            detail: Any = results[idx].get("detail")
+            if isinstance(detail, dict):
+                detail_payload: Dict[str, Any] = detail
+            elif detail is None:
+                detail_payload = {}
+            else:
+                detail_payload = {"payload": detail}
+
+            if isinstance(log_result, Exception):
+                detail_payload["log_error"] = str(log_result)
+            else:
+                detail_payload["log_id"] = log_result
+
+            results[idx]["detail"] = detail_payload
+
+    overall_success = all(result.get("success") for result in results)
+
+    status_code = status.HTTP_200_OK if overall_success else status.HTTP_207_MULTI_STATUS
+    return JSONResponse(status_code=status_code, content={"results": results})

--- a/alerts/src/channels.py
+++ b/alerts/src/channels.py
@@ -1,0 +1,117 @@
+"""Alert delivery channels."""
+from __future__ import annotations
+
+import asyncio
+from email.message import EmailMessage
+from typing import Any, Dict, Iterable
+
+import httpx
+
+from .config import (
+    ConfigurationError,
+    get_email_sender,
+    get_smtp_host,
+    get_smtp_password,
+    get_smtp_port,
+    get_smtp_use_tls,
+    get_smtp_username,
+    get_telegram_token,
+)
+
+
+ChannelStatus = Dict[str, Any]
+
+
+def _build_status(
+    channel: str,
+    target: Any,
+    success: bool,
+    *,
+    error: str | None = None,
+    detail: Any | None = None,
+) -> ChannelStatus:
+    return {
+        "channel": channel,
+        "target": target,
+        "success": success,
+        "error": error,
+        "detail": detail,
+    }
+
+
+async def send_telegram_alert(chat_id: str, text: str) -> ChannelStatus:
+    """Send an alert through Telegram."""
+    try:
+        token = get_telegram_token()
+    except ConfigurationError as exc:
+        return _build_status(
+            "telegram",
+            chat_id,
+            False,
+            error=str(exc),
+        )
+
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = {"chat_id": chat_id, "text": text}
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        try:
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            detail = getattr(exc, "response", None)
+            status_code = detail.status_code if detail is not None else None
+            return _build_status(
+                "telegram",
+                chat_id,
+                False,
+                error=str(exc),
+                detail={"status_code": status_code},
+            )
+
+    return _build_status("telegram", chat_id, True)
+
+
+async def send_email_alert(
+    recipients: Iterable[str],
+    subject: str,
+    body: str,
+) -> ChannelStatus:
+    """Send an alert email using the configured SMTP server."""
+    recipients_list = list(recipients)
+
+    try:
+        smtp_host = get_smtp_host()
+        smtp_port = get_smtp_port()
+        use_tls = get_smtp_use_tls()
+        username = get_smtp_username()
+        password = get_smtp_password()
+        sender = get_email_sender()
+    except ConfigurationError as exc:
+        return _build_status("email", recipients_list, False, error=str(exc))
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = sender
+    message["To"] = ", ".join(recipients_list)
+    message.set_content(body)
+
+    def _send_email() -> None:
+        import smtplib
+
+        with smtplib.SMTP(smtp_host, smtp_port) as server:
+            if use_tls:
+                server.starttls()
+            if username and password:
+                server.login(username, password)
+            server.send_message(message)
+
+    try:
+        await asyncio.to_thread(_send_email)
+    except Exception as exc:
+        return _build_status("email", recipients_list, False, error=str(exc))
+
+    return _build_status("email", recipients_list, True)
+
+
+__all__ = ["send_telegram_alert", "send_email_alert", "ChannelStatus"]

--- a/alerts/src/config.py
+++ b/alerts/src/config.py
@@ -1,0 +1,111 @@
+"""Configuration helpers for the alerts service."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+from azure.identity import ClientSecretCredential
+from azure.keyvault.secrets import SecretClient
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when required configuration values are missing or invalid."""
+
+
+def _get_env(name: str, *, default: Optional[str] = None) -> str:
+    """Retrieve an environment variable with validation."""
+    value = os.getenv(name, default)
+    if value is None or value == "":
+        raise ConfigurationError(f"Environment variable '{name}' is required")
+    return value
+
+
+@lru_cache
+def get_secret_client() -> SecretClient:
+    """Return a cached instance of :class:`~azure.keyvault.secrets.SecretClient`."""
+
+    tenant_id = _get_env("AZURE_TENANT_ID")
+    client_id = _get_env("AZURE_CLIENT_ID")
+    client_secret = _get_env("AZURE_CLIENT_SECRET")
+    vault_url = _get_env("AZURE_VAULT_URL")
+
+    credential = ClientSecretCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    return SecretClient(vault_url=vault_url, credential=credential)
+
+
+def _get_secret(name_env_var: str) -> str:
+    secret_name = _get_env(name_env_var)
+    secret = get_secret_client().get_secret(secret_name)
+    return secret.value
+
+
+@lru_cache
+def get_telegram_token() -> str:
+    return _get_secret("ALERTS_TELEGRAM_TOKEN_SECRET_NAME")
+
+
+@lru_cache
+def get_smtp_username() -> str:
+    return _get_secret("ALERTS_SMTP_USERNAME_SECRET_NAME")
+
+
+@lru_cache
+def get_smtp_password() -> str:
+    return _get_secret("ALERTS_SMTP_PASSWORD_SECRET_NAME")
+
+
+@lru_cache
+def get_email_sender() -> str:
+    return _get_secret("ALERTS_EMAIL_FROM_SECRET_NAME")
+
+
+def get_smtp_host() -> str:
+    return _get_env("ALERTS_SMTP_HOST")
+
+
+def get_smtp_port() -> int:
+    value = _get_env("ALERTS_SMTP_PORT")
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ConfigurationError("ALERTS_SMTP_PORT must be an integer") from exc
+
+
+def get_smtp_use_tls() -> bool:
+    value = _get_env("ALERTS_SMTP_USE_TLS")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@lru_cache
+def get_database_url() -> str:
+    """Return the SQLAlchemy database URL for persisting alert logs."""
+
+    secret_name = os.getenv("ALERTS_DATABASE_URL_SECRET_NAME")
+    if secret_name:
+        secret_value = get_secret_client().get_secret(secret_name).value
+        if not secret_value:
+            raise ConfigurationError(
+                "Secret referenced by ALERTS_DATABASE_URL_SECRET_NAME is empty"
+            )
+        return secret_value
+
+    return _get_env("ALERTS_DATABASE_URL")
+
+
+__all__ = [
+    "ConfigurationError",
+    "get_secret_client",
+    "get_telegram_token",
+    "get_smtp_username",
+    "get_smtp_password",
+    "get_email_sender",
+    "get_smtp_host",
+    "get_smtp_port",
+    "get_smtp_use_tls",
+    "get_database_url",
+]

--- a/alerts/src/db.py
+++ b/alerts/src/db.py
@@ -1,0 +1,96 @@
+"""Database utilities for persisting alert delivery logs."""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    JSON,
+    String,
+    Text,
+    create_engine,
+    func,
+)
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from .config import get_database_url
+
+
+Base = declarative_base()
+
+
+class AlertMessage(Base):
+    """ORM model storing each alert delivery attempt."""
+
+    __tablename__ = "alert_messages"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    channel = Column(String(50), nullable=False)
+    target = Column(Text, nullable=False)
+    subject = Column(Text, nullable=True)
+    message = Column(Text, nullable=False)
+    success = Column(Boolean, nullable=False, default=False)
+    error = Column(Text, nullable=True)
+    detail = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+engine = create_engine(get_database_url(), pool_pre_ping=True, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def init_db() -> None:
+    """Create database tables if they do not already exist."""
+
+    Base.metadata.create_all(bind=engine)
+
+
+def _stringify_target(target: Any) -> str:
+    if isinstance(target, str):
+        return target
+    if isinstance(target, Iterable):
+        return ", ".join(str(item) for item in target)
+    return str(target)
+
+
+def _normalize_detail(detail: Any) -> Any:
+    if detail is None or isinstance(detail, (dict, list)):
+        return detail
+    return str(detail)
+
+
+def create_alert_log(
+    *,
+    channel: str,
+    target: Any,
+    message: str,
+    subject: str | None,
+    success: bool,
+    error: str | None,
+    detail: Any,
+) -> int:
+    """Persist an alert delivery attempt and return the new record ID."""
+
+    normalized_target = _stringify_target(target)
+    normalized_detail = _normalize_detail(detail)
+
+    with SessionLocal() as session:
+        record = AlertMessage(
+            channel=channel,
+            target=normalized_target,
+            subject=subject,
+            message=message,
+            success=success,
+            error=error,
+            detail=normalized_detail,
+        )
+        session.add(record)
+        session.commit()
+        session.refresh(record)
+        return record.id
+
+
+__all__ = ["AlertMessage", "create_alert_log", "init_db"]


### PR DESCRIPTION
## Summary
- scaffold a new FastAPI-based alerts service with Telegram and email delivery orchestration
- implement channel helpers that read secrets from Azure Key Vault and send messages via httpx and smtplib
- add service dependencies and Dockerfile for containerized deployment
- persist each alert delivery in the database and expose log identifiers in responses

## Testing
- PYTHONDONTWRITEBYTECODE=1 python -m compileall alerts/src

------
https://chatgpt.com/codex/tasks/task_e_68cc000b01c48329bed9b9cf521e849c